### PR TITLE
todoとlabelの紐付け

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -11,7 +11,9 @@ class LabelSerializer(serializers.ModelSerializer):
 
 
 class TodoSerializer(serializers.ModelSerializer):
-    labels = LabelSerializer(read_only=True)
+    # labels = serializers.StringRelatedField()
+    labels = serializers.PrimaryKeyRelatedField(queryset=Label.objects.filter(), many=True)
+    # labels = LabelSerializer(read_only=True)
 
     class Meta:
         model = Todo

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -11,16 +11,22 @@ class LabelSerializer(serializers.ModelSerializer):
 
 
 class TodoSerializer(serializers.ModelSerializer):
-    # NOTE:get専用主キー指定
-    # labels = serializers.StringRelatedField()
-    # NOTE:post可能主キー指定
-    # labels = serializers.PrimaryKeyRelatedField(queryset=Label.objects.filter(), many=True)
-    # NOTE:ネスト表示だがgetしか出来ない
-    labels = LabelSerializer(many=True, read_only=True)
+    # NOTE:list時にカラム表示
+    labels = LabelSerializer(
+        many=True,
+        read_only=True,
+    )
+    # NOTE:書き込み時は主キー指定
+    labels_id = serializers.PrimaryKeyRelatedField(
+        source='labels',
+        queryset=Label.objects.filter(),  # FIXME:user_idによるフィルタリング
+        many=True,
+        write_only=True,
+    )
 
     class Meta:
         model = Todo
-        fields = ('id', 'user_id', 'title', 'finished_flag', 'deadline', 'important', 'memo', 'labels')
+        fields = ('id', 'user_id', 'title', 'finished_flag', 'deadline', 'important', 'memo', 'labels', 'labels_id')
         read_only_fields = ['id']
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -11,9 +11,12 @@ class LabelSerializer(serializers.ModelSerializer):
 
 
 class TodoSerializer(serializers.ModelSerializer):
+    # NOTE:get専用主キー指定
     # labels = serializers.StringRelatedField()
-    labels = serializers.PrimaryKeyRelatedField(queryset=Label.objects.filter(), many=True)
-    # labels = LabelSerializer(read_only=True)
+    # NOTE:post可能主キー指定
+    # labels = serializers.PrimaryKeyRelatedField(queryset=Label.objects.filter(), many=True)
+    # NOTE:ネスト表示だがgetしか出来ない
+    labels = LabelSerializer(many=True, read_only=True)
 
     class Meta:
         model = Todo

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -19,7 +19,7 @@ class TodoSerializer(serializers.ModelSerializer):
     # NOTE:書き込み時は主キー指定
     labels_id = serializers.PrimaryKeyRelatedField(
         source='labels',
-        queryset=Label.objects.filter(),  # FIXME:user_idによるフィルタリング
+        queryset=Label.objects.all(),
         many=True,
         write_only=True,
     )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -6,7 +6,7 @@ from users.models import User
 class LabelSerializer(serializers.ModelSerializer):
     class Meta:
         model = Label
-        fields = ('id', 'user_id', 'title', 'coler_code')
+        fields = ('id', 'user_id', 'title', 'color_code')
         read_only_fields = ['id']
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,19 +3,19 @@ from todolist.models import Todo, Label
 from users.models import User
 
 
-class TodoSerializer(serializers.ModelSerializer):
-    labels = serializers.StringRelatedField
-
-    class Meta:
-        model = Todo
-        fields = ('id', 'user_id', 'title', 'finished_flag', 'deadline', 'important', 'memo', 'labels')
-        read_only_fields = ['id']
-
-
 class LabelSerializer(serializers.ModelSerializer):
     class Meta:
         model = Label
         fields = ('id', 'user_id', 'title', 'coler_code')
+        read_only_fields = ['id']
+
+
+class TodoSerializer(serializers.ModelSerializer):
+    labels = LabelSerializer()
+
+    class Meta:
+        model = Todo
+        fields = ('id', 'user_id', 'title', 'finished_flag', 'deadline', 'important', 'memo', 'labels')
         read_only_fields = ['id']
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -4,9 +4,11 @@ from users.models import User
 
 
 class TodoSerializer(serializers.ModelSerializer):
+    labels = serializers.StringRelatedField
+
     class Meta:
         model = Todo
-        fields = ('id', 'user_id', 'title', 'finished_flag', 'deadline', 'important', 'memo')
+        fields = ('id', 'user_id', 'title', 'finished_flag', 'deadline', 'important', 'memo', 'labels')
         read_only_fields = ['id']
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -11,7 +11,7 @@ class LabelSerializer(serializers.ModelSerializer):
 
 
 class TodoSerializer(serializers.ModelSerializer):
-    labels = LabelSerializer()
+    labels = LabelSerializer(read_only=True)
 
     class Meta:
         model = Todo

--- a/todolist/admin.py
+++ b/todolist/admin.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
-from .models import Todo, Label, Todo_Label
+from .models import Todo, Label
 
 admin.site.register(Todo)
 admin.site.register(Label)
-admin.site.register(Todo_Label)

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -44,15 +44,3 @@ class Todo(models.Model):
         Label,
         blank=True,
     )
-
-
-# FIXME:中間テーブルは自動生成される為、独自のパラメータを持たせない場合は明示不要。
-class Todo_Label(models.Model):
-    todo_id = models.ForeignKey(
-        Todo,
-        on_delete=models.CASCADE,
-    )
-    label_id = models.ForeignKey(
-        Label,
-        on_delete=models.CASCADE,
-    )

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -8,7 +8,7 @@ class Label(models.Model):
         on_delete=models.CASCADE,
     )
     title = models.CharField(max_length=16)
-    coler_code = models.CharField(
+    color_code = models.CharField(
         max_length=7,
         null=True,
         blank=True,

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -25,15 +25,15 @@ class Todo(models.Model):
         null=True,
         blank=True,
     )
-    IMPORTANT = (
-        (0, 'Nothing'),
-        (1, 'Low'),
-        (2, 'Medium'),
-        (3, 'High'),
-    )
     important = models.IntegerField(
-        choices=IMPORTANT,
+        choices=(
+            (0, 'Nothing'),
+            (1, 'Low'),
+            (2, 'Medium'),
+            (3, 'High'),
+        ),
         default=0,
+        blank=True,
     )
     memo = models.CharField(
         max_length=255,

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -38,6 +38,7 @@ class Todo(models.Model):
     )
 
 
+# FIXME:'user_id'をモデルで引いているので、フィールドのリレーにシリアライザーを使うとエラーが出る
 class Label(models.Model):
     user_id = models.ForeignKey(
         get_user_model(),

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -1,8 +1,22 @@
 from django.db import models
 from django.contrib.auth import get_user_model
 
+
 # class [テーブル名](models.Model):
 #     フィールド名 = models.[適切な型]([オプション])
+
+
+# FIXME:'user_id'をモデルで引いているので、フィールドのリレーにシリアライザーを使うとエラーが出る
+class Label(models.Model):
+    user_id = models.ForeignKey(
+        get_user_model(),
+        on_delete=models.CASCADE,
+    )
+    title = models.CharField(max_length=16)
+    coler_code = models.CharField(
+        max_length=7,
+        null=True,
+    )
 
 
 class Todo(models.Model):
@@ -32,21 +46,8 @@ class Todo(models.Model):
         blank=True,
     )
     labels = models.ManyToManyField(
-        "Label",
+        Label,
         blank=True,
-        null=True,
-    )
-
-
-# FIXME:'user_id'をモデルで引いているので、フィールドのリレーにシリアライザーを使うとエラーが出る
-class Label(models.Model):
-    user_id = models.ForeignKey(
-        get_user_model(),
-        on_delete=models.CASCADE,
-    )
-    title = models.CharField(max_length=16)
-    coler_code = models.CharField(
-        max_length=7,
         null=True,
     )
 

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -48,7 +48,6 @@ class Todo(models.Model):
     labels = models.ManyToManyField(
         Label,
         blank=True,
-        null=True,
     )
 
 

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -31,6 +31,11 @@ class Todo(models.Model):
         null=True,
         blank=True,
     )
+    labels = models.ManyToManyField(
+        "Label",
+        blank=True,
+        null=True,
+    )
 
 
 class Label(models.Model):
@@ -45,6 +50,7 @@ class Label(models.Model):
     )
 
 
+# FIXME:中間テーブルは自動生成される為、独自のパラメータを持たせない場合は明示不要。
 class Todo_Label(models.Model):
     todo_id = models.ForeignKey(
         Todo,

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -2,11 +2,6 @@ from django.db import models
 from django.contrib.auth import get_user_model
 
 
-# class [テーブル名](models.Model):
-#     フィールド名 = models.[適切な型]([オプション])
-
-
-# FIXME:'user_id'をモデルで引いているので、フィールドのリレーにシリアライザーを使うとエラーが出る
 class Label(models.Model):
     user_id = models.ForeignKey(
         get_user_model(),

--- a/todolist/models.py
+++ b/todolist/models.py
@@ -11,6 +11,7 @@ class Label(models.Model):
     coler_code = models.CharField(
         max_length=7,
         null=True,
+        blank=True,
     )
 
 
@@ -33,7 +34,6 @@ class Todo(models.Model):
             (3, 'High'),
         ),
         default=0,
-        blank=True,
     )
     memo = models.CharField(
         max_length=255,
@@ -42,5 +42,4 @@ class Todo(models.Model):
     )
     labels = models.ManyToManyField(
         Label,
-        blank=True,
     )


### PR DESCRIPTION
## 概要

<!--
* なぜこの変更をするのかなど、概要を記載
* 必要であればwikiやslackなどへのリンクを貼る
-->

作成したLabelをTodoに紐付ける。
一つのTodoに複数のLabelを、また、一つのLabelを複数のTodoに紐付ける機能。

その他、`todolist/models.py`のリファクタリング（無意味なblank=Trueの削除等）を実施。

* fix #11 #19

## 使い方

<!--
* 使い方の説明
* この Pull Request のレビュアーが、挙動を確かめる時に困らないように記述する
* 例えば、機能追加であれば、その機能の使い方やその機能までの動線
* バグであれば、その再現条件 (例えば、デバイスの状態、設定によってこういう風に使える、とかこういう画面が出てくる、とか条件があれば)
-->

`api/labels/`でLabelが作成されているものとする。

`api/todos/`でのPOST（新規作成）及び`api/todos/{todo_id}`のPUT（更新）

`labels_id`にlabelの主キーをタプル形式で指定すると、紐付けされる。
例えば、以下をrequestする。

```
{
    "user_id": 1,
    "title": "label紐付けテスト",
    "finished_flag": false,
    "deadline": null,
    "important": 0,
    "memo": "これはlabelの紐付けテストです",
    "labels_id": [1,2]
}
```

戻り値は以下となる。

```
{
    "id": 6,
    "user_id": 1,
    "title": "label紐付けテスト",
    "finished_flag": false,
    "deadline": null,
    "important": 0,
    "memo": "これはlabelの紐付けテストです",
    "labels": [
        {
            "id": 1,
            "user_id": 1,
            "title": "test1",
            "coler_code": ""
        },
        {
            "id": 2,
            "user_id": 1,
            "title": "test2",
            "coler_code": "test2"
        }
    ]
}
```

POSTとPUTでは`labels_id`に主キーを登録する。
GET（あるいは戻り値）の一覧では、`label`にラベルの情報がnestされて表示される。

## Request/Responseの主な変更点

<!-- APIのレスポンスが変わった場合の変更点 -->

## 技術的変更点概要

<!--
* なにをどう変更したか
* ロジックがどういう手順で動くのか、
* レビュワーにわかるように、技術的視線での変更概要説明
-->

* todolist/models.py

無意味な`blank=True`の削除
文中に突然現れるリスト定義を`choices`の中に移動
`class Todo`でLabelを`ManyToManyField`で定義。
`class Todo_label`による中間テーブルは、上記の設定で動的に作成される為、削除。

* api/serializers.py

`TodoSerializer`が`LabelSerializer`を参照する為、classの記載順を入れ替え。
`LabelSerializer`は変更無し。
`TodoSerializer`のフィールドに`labels`と`labels_id`を定義。
`labels`フィールドを表示する際は、`LabelSerializer`を指定することで、GETで使用されるlistアクションでnestして読み込む。
しかし、POSTやPUTには対応していない。
その為、`labels_id`フィールドを別途定義して、labelsの主キーを指定、使用し、TodoとLabelの紐付けを行う。

* todolist/admin.py

`Todo_Label`モデルを消したので削除。


## DB変更点

<!--
* マイグレーションが必要な場合、その内容
-->

多対多の中間テーブルが作成される為、マイグレーションが必要です。
動的に作成されるテーブルは`todolist_todo_labels`なので名前は被らないみたいですが、DB毎作り直さないと動かないかもしれない…。

## テスト結果とテスト項目

<!--
していない場合はしていないと書いてください。

* [ ] テストする際の項目を、このように、チェック可能な形式で記載する。
* [ ] レビュワーがなるべく再テストできるように、具体的に書くこと
* [ ] 概要などと被る記述になるかもしれないけど、それでも書くこと
* [ ] 機能のON/OFF によって画面の出しわけ、機能が有効になったり無効になったりする場合、場合分けしてテスト項目を書く
-->

* [ ] 「使い方」に記載したPOSTが行えること。
* [ ] `api/todos/`へのPOSTで"labels_id"に存在する複数のLabelを指定してTodoが登録出来ること。
* [ ] `api/todos/{id}`へのPUTで"labels_id"に存在する複数のLabelを指定してTodoが登録出来ること。
* [ ] 一つのLabelが異なるIDのTodoに登録出来ること。
* [ ] admin画面へのログイン
* [ ] `api/labels/`へのPOSTによるLabelの作成。


## 今回保留した項目とTODOリスト

<!--
箇条書きで書く。できれば次のissueを作る。

* あれこれを治す #xxxxxx
* あれそれを実装する #xxxxxx
-->

TodoとLabelのユーザーIDが合致しているかどうかを確認出来ていない気がする。